### PR TITLE
Chrome系のプロファイルのパスを修正した

### DIFF
--- a/CookieGetterSharp/BrowserType.cs
+++ b/CookieGetterSharp/BrowserType.cs
@@ -143,6 +143,11 @@ namespace Hal.CookieGetterSharp
         /// <summary>
         /// Tungsten
         /// </summary>
-        TungstenBlink
+        TungstenBlink,
+
+        /// <summary>
+        /// ChromeCanary
+        /// </summary>
+        ChromeCanary
     }
 }

--- a/CookieGetterSharp/ChromeCanaryBrowserManager.cs
+++ b/CookieGetterSharp/ChromeCanaryBrowserManager.cs
@@ -5,10 +5,10 @@ using System.IO;
 
 namespace Hal.CookieGetterSharp
 {
-    class GoogleChromeBrowserManager : IBrowserManager
+    class ChromeCanaryBrowserManager : IBrowserManager
     {
         // プロファイル対応 4/26
-        private readonly string DATAFOLDER = "%LOCALAPPDATA%\\Google\\Chrome\\User Data\\";
+        private readonly string DATAFOLDER = "%LOCALAPPDATA%\\Google\\Chrome SxS\\User Data\\";
         private readonly string DefaultFolder = "Default";
         private readonly string ProfileFolderStarts = "Profile";
         private readonly string COOKEFILE_NAME = "Cookies";
@@ -17,7 +17,7 @@ namespace Hal.CookieGetterSharp
 
         public BrowserType BrowserType
         {
-            get { return BrowserType.GoogleChrome; }
+            get { return BrowserType.ChromeCanary; }
         }
 
         public ICookieGetter CreateDefaultCookieGetter()

--- a/CookieGetterSharp/ChromiumBrowserManager.cs
+++ b/CookieGetterSharp/ChromiumBrowserManager.cs
@@ -57,8 +57,13 @@ namespace Hal.CookieGetterSharp
                 string[] path = Directory.GetDirectories(folder);
                 for(int i = 0;i < path.Length;i++) {
                     if(Path.GetFileName(path[i]).StartsWith(ProfileFolderStarts, StringComparison.OrdinalIgnoreCase)) {
-                        if(File.Exists(Path.Combine(path[i], COOKEFILE_NAME))) {
-                            profiles.Add(path[i]);
+                        String profileDefaultFolder = Path.Combine(path[i], DefaultFolder);
+                        if (Directory.Exists(profileDefaultFolder))
+                        {
+                            if (File.Exists(Path.Combine(profileDefaultFolder, COOKEFILE_NAME)))
+                            {
+                                profiles.Add(profileDefaultFolder);
+                            }
                         }
                     }
                 }
@@ -72,7 +77,7 @@ namespace Hal.CookieGetterSharp
             string path = null;
 
             if(prof != null) {
-                name += " " + Path.GetFileName(prof);
+                name += " " + Directory.GetParent(prof).Name;
                 path = System.IO.Path.Combine(prof, COOKEFILE_NAME);
             }
 

--- a/CookieGetterSharp/CookieGetter.cs
+++ b/CookieGetterSharp/CookieGetter.cs
@@ -42,7 +42,8 @@ namespace Hal.CookieGetterSharp {
                 new CoolNovoBrowserManager(),
                 //new RockMeltBrowserManager(),
                 new MaxthonBrowserManager(),
-                new TungstenBrowserManager()
+                new TungstenBrowserManager(),
+                new ChromeCanaryBrowserManager(),
             };
         }
 

--- a/CookieGetterSharp/CookieGetterSharp.csproj
+++ b/CookieGetterSharp/CookieGetterSharp.csproj
@@ -122,6 +122,7 @@
     <Compile Include="FirefoxBrowserManager.cs" />
     <Compile Include="FirefoxCookieGetter.cs" />
     <Compile Include="FirefoxProfile.cs" />
+    <Compile Include="ChromeCanaryBrowserManager.cs" />
     <Compile Include="GoogleChromeBrowserManager.cs" />
     <Compile Include="GoogleChromeCookieGetter.cs" />
     <Compile Include="IBrowserManager.cs" />


### PR DESCRIPTION
※注意点
どのリビジョンからプロファイルのパスが変わったのかはまだ掴めていません；；
CoolNovoなどの使ったこと無いChrome系ブラウザについては修正していません；；；；
※テストしたブラウザのバーション
GoogleChrome 40.0.2214.115
Chromium 41.0.2246.0
ChromeCanary 43.0.2322.3
変更前のパス
\User Data\Profile***_\Cookies
変更後のパス
\User Data\Profile**_*\Default\Cookies
変更したBrowserManager
ChromiumBrowserManager.cs
GoogleChromeBrowserManager.cs
新規追加したBrowserManager
ChromeCanaryBrowserManager.cs
